### PR TITLE
initializing width/height for the first call to Application::reset

### DIFF
--- a/src/bigg.cpp
+++ b/src/bigg.cpp
@@ -123,6 +123,8 @@ void bigg::Application::imguiEvents( float dt )
 
 bigg::Application::Application()
 {
+	mWidth = 1280;
+	mHeight = 768;
 	mMousePressed[ 0 ] = false;
 	mMousePressed[ 1 ] = false;
 	mMousePressed[ 2 ] = false;
@@ -139,7 +141,7 @@ int bigg::Application::run( int argc, char** argv, bgfx::RendererType::Enum type
 
 	// Create a window
 	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
-	mWindow = glfwCreateWindow( 1280, 768, "", NULL, NULL );
+	mWindow = glfwCreateWindow( getWidth(), getHeight(), "", NULL, NULL );
 	if ( !mWindow )
 	{
 		glfwTerminate();


### PR DESCRIPTION
```Application::reset()``` is getting called twice in native builds - when initializing and on the first time ```update()``` is called (because ```glfwGetWindowSize()``` returns the proper values and when compared to the uninitialized ones they are different). The first time the width/height are garbage values and are passed to ```bgfx::reset()``` but the second call fixes that.

This was a problem when building the example with emscripten for asm.js - took me a few hours to figure out why after ```bgfx::init()``` was successful my canvas disappeared.