### PR TITLE
Add const qualifiers to class member functions

### DIFF
--- a/include/bigg.hpp
+++ b/include/bigg.hpp
@@ -67,8 +67,8 @@ namespace bigg
 		);
 
 		void reset( uint32_t flags = 0 );
-		uint32_t getWidth();
-		uint32_t getHeight();
+		uint32_t getWidth() const;
+		uint32_t getHeight() const;
 
 		virtual void initialize( int _argc, char** _argv ) {};
 		virtual void update( float dt ) {};

--- a/src/bigg.cpp
+++ b/src/bigg.cpp
@@ -305,12 +305,12 @@ void bigg::Application::reset( uint32_t flags )
 	onReset();
 }
 
-uint32_t bigg::Application::getWidth()
+uint32_t bigg::Application::getWidth() const
 {
 	return mWidth;
 }
 
-uint32_t bigg::Application::getHeight()
+uint32_t bigg::Application::getHeight() const
 {
 	return mHeight;
 }


### PR DESCRIPTION
I added `const` qualifiers to `bigg::Application`'s member functions. Specifically, I changed

- `bigg::Application::getWidth()` to `bigg::Application::getWidth() const`
- `bigg::Application::getHeight()` to `bigg::Application::getHeight() const`

I created a subclass derived from `bigg::Application` and I defined a member function in which `getWidth()` and `getHeight()` were used. I wanted to make the new member function `const` as it would not change anything, but it was not possible because `getWidth()` and `getHeight()` were not marked as `const`.

I am not aware of any disadvantages about not to mark member functions as `const` when applicable. However, please feel free to close (without merge) this PR if you intentionally dropped `const` qualifiers for some reasons.

Thank you for this very useful project.
