### PR TITLE
Added window size and title controls

### DIFF
--- a/examples/cubes/cubes.cpp
+++ b/examples/cubes/cubes.cpp
@@ -111,6 +111,9 @@ class ExampleCubes : public bigg::Application
 			}
 		}
 	}
+public:
+	ExampleCubes()
+		: bigg::Application( "Cubes", 960, 720 ) {}
 private:
 	bgfx::ProgramHandle mProgram;
 	bgfx::VertexBufferHandle mVbh;

--- a/examples/imgui_demo/imgui_demo.cpp
+++ b/examples/imgui_demo/imgui_demo.cpp
@@ -19,6 +19,9 @@ class ExampleImguiDemo : public bigg::Application
 		bgfx::touch( 0 );
 		ImGui::ShowDemoWindow();
 	}
+public:
+	ExampleImguiDemo()
+		: bigg::Application( "Imgui Demo" ) {}
 };
 
 int main( int argc, char** argv )

--- a/include/bigg.hpp
+++ b/include/bigg.hpp
@@ -51,10 +51,11 @@ namespace bigg
 		static void cursorEnterCallback( GLFWwindow* window, int entered );
 		static void scrollCallback( GLFWwindow* window, double xoffset, double yoffset );
 		static void dropCallback( GLFWwindow* window, int count, const char** paths );
+		static void windowSizeCallback( GLFWwindow* window, int width, int height );
 
 		void imguiEvents( float dt );
 	public:
-		Application();
+		Application( const char* title = "", uint32_t width = 1280, uint32_t height = 768 );
 
 		int run(
 			int argc,
@@ -69,6 +70,9 @@ namespace bigg
 		void reset( uint32_t flags = 0 );
 		uint32_t getWidth() const;
 		uint32_t getHeight() const;
+		void setSize( int width, int height );
+		const char* getTitle() const;
+		void setTitle( const char* title );
 
 		virtual void initialize( int _argc, char** _argv ) {};
 		virtual void update( float dt ) {};
@@ -83,6 +87,7 @@ namespace bigg
 		virtual void onCursorEnter( int entered ) {}
 		virtual void onScroll( double xoffset, double yoffset ) {}
 		virtual void onDrop( int count, const char** paths ) {}
+		virtual void onWindowSize( int width, int height ) {}
 	protected:
 		GLFWwindow* mWindow;
 		bigg::Allocator mAllocator;
@@ -90,6 +95,7 @@ namespace bigg
 		uint32_t mReset;
 		uint32_t mWidth;
 		uint32_t mHeight;
+		const char* mTitle;
 		bool  mMousePressed[ 3 ];
 		float mMouseWheel;
 	};

--- a/src/bigg.cpp
+++ b/src/bigg.cpp
@@ -156,6 +156,15 @@ void bigg::Application::dropCallback( GLFWwindow* window, int count, const char*
 	app->onDrop( count, paths );
 }
 
+void bigg::Application::windowSizeCallback( GLFWwindow* window, int width, int height )
+{
+	bigg::Application* app = ( bigg::Application* )glfwGetWindowUserPointer( window );
+	app->mWidth = width;
+	app->mHeight = height;
+	app->reset( app->mReset );
+	app->onWindowSize( width, height );
+}
+
 void bigg::Application::imguiEvents( float dt )
 {
 	ImGuiIO& io = ImGui::GetIO();
@@ -190,10 +199,11 @@ void bigg::Application::imguiEvents( float dt )
 #endif
 }
 
-bigg::Application::Application()
+bigg::Application::Application( const char* title, uint32_t width, uint32_t height )
 {
-	mWidth = 1280;
-	mHeight = 768;
+	mWidth = width;
+	mHeight = height;
+	mTitle = title;
 	mMousePressed[ 0 ] = false;
 	mMousePressed[ 1 ] = false;
 	mMousePressed[ 2 ] = false;
@@ -210,7 +220,7 @@ int bigg::Application::run( int argc, char** argv, bgfx::RendererType::Enum type
 
 	// Create a window
 	glfwWindowHint( GLFW_CLIENT_API, GLFW_NO_API );
-	mWindow = glfwCreateWindow( getWidth(), getHeight(), "", NULL, NULL );
+	mWindow = glfwCreateWindow( getWidth(), getHeight(), getTitle(), NULL, NULL );
 	if ( !mWindow )
 	{
 		glfwTerminate();
@@ -220,11 +230,6 @@ int bigg::Application::run( int argc, char** argv, bgfx::RendererType::Enum type
 	// Setup input callbacks
 	glfwSetWindowUserPointer( mWindow, this );
 	glfwSetKeyCallback( mWindow, keyCallback );
-	glfwSetMouseButtonCallback( mWindow, mouseButtonCallback );
-	glfwSetScrollCallback( mWindow, scrollCallback );
-	glfwSetCharCallback( mWindow, charCallback );
-
-	glfwSetKeyCallback( mWindow, keyCallback );
 	glfwSetCharCallback( mWindow, charCallback );
 	glfwSetCharModsCallback( mWindow, charModsCallback );
 	glfwSetMouseButtonCallback( mWindow, mouseButtonCallback );
@@ -232,6 +237,7 @@ int bigg::Application::run( int argc, char** argv, bgfx::RendererType::Enum type
 	glfwSetCursorEnterCallback( mWindow, cursorEnterCallback );
 	glfwSetScrollCallback( mWindow, scrollCallback );
 	glfwSetDropCallback( mWindow, dropCallback );
+	glfwSetWindowSizeCallback( mWindow, windowSizeCallback );
 
 	// Setup bgfx
 	bgfx::PlatformData platformData;
@@ -278,15 +284,6 @@ int bigg::Application::run( int argc, char** argv, bgfx::RendererType::Enum type
 		update( dt );
 		ImGui::Render();
 		bgfx::frame();
-
-		int w, h;
-		glfwGetWindowSize( mWindow, &w, &h );
-		if ( w != mWidth || h != mHeight )
-		{
-			mWidth = w;
-			mHeight = h;
-			reset( mReset );
-		}
 	}
 
 	// Shutdown application and glfw
@@ -313,4 +310,20 @@ uint32_t bigg::Application::getWidth() const
 uint32_t bigg::Application::getHeight() const
 {
 	return mHeight;
+}
+
+void bigg::Application::setSize( int width, int height )
+{
+	glfwSetWindowSize( mWindow, width, height );
+}
+
+const char* bigg::Application::getTitle() const
+{
+	return mTitle;
+}
+
+void bigg::Application::setTitle( const char* title )
+{
+	mTitle = title;
+	glfwSetWindowTitle( mWindow, title);
 }


### PR DESCRIPTION
Attempts to fix #12. Adds optional parameters for title, width, and height to the application constructor. Adds methods to get/set the size and title of the window. Also adds a window resize callback. Removed duplicate calls to the GLFW set callback functions in the [application run method](https://github.com/JoshuaBrookover/bigg/blob/master/src/bigg.cpp#L222-L225). These duplicate calls may have been intentional so please verify that they should be removed.