### PR TITLE
Don't pass imgui scroll event to application if the mouse is captured

### DIFF
--- a/src/bigg.cpp
+++ b/src/bigg.cpp
@@ -122,8 +122,12 @@ void bigg::Application::cursorEnterCallback( GLFWwindow* window, int entered )
 void bigg::Application::scrollCallback( GLFWwindow* window, double xoffset, double yoffset )
 {
 	bigg::Application* app = ( bigg::Application* )glfwGetWindowUserPointer( window );
+	ImGuiIO& io = ImGui::GetIO();
 	app->mMouseWheel += (float)yoffset;
-	app->onScroll( xoffset, yoffset );
+	if ( !io.WantCaptureMouse )
+	{
+		app->onScroll( xoffset, yoffset );
+	}
 }
 
 void bigg::Application::dropCallback( GLFWwindow* window, int count, const char** paths )


### PR DESCRIPTION
Tiny fix to prevent mouse scrolling in imgui windows to be passed along to the app