### PR TITLE
Call imgui render function directly

### DIFF
--- a/src/bigg.cpp
+++ b/src/bigg.cpp
@@ -239,6 +239,7 @@ int bigg::Application::run( int argc, char** argv, bgfx::RendererType::Enum type
 		ImGui::NewFrame();
 		update( dt );
 		ImGui::Render();
+		imguiRender( ImGui::GetDrawData() );
 		bgfx::frame();
 	}
 

--- a/src/bigg_imgui.hpp
+++ b/src/bigg_imgui.hpp
@@ -42,9 +42,6 @@ static void imguiInit( GLFWwindow* window )
 	bgfx::ShaderHandle fs = bgfx::createShader( bgfx::makeRef( fs_ocornut_imgui(), fs_ocornut_imgui_len() ) );
 	imguiProgram = bgfx::createProgram( vs, fs, true );
 
-	// Setup render callback
-	io.RenderDrawListsFn = imguiRender;
-
 	// Setup back-end capabilities flags
 	io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
 	io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;


### PR DESCRIPTION
This change calls the imgui drawlist render function directly, instead of setting the callback and letting imgui call it at the end of `ImGui::Render`. The latter is deprecated since 1.60 and won't compile with `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` defined.